### PR TITLE
Fix logs and status update in Release config

### DIFF
--- a/Publish/StoreBroker/Pdp/en-us/PDP.xml
+++ b/Publish/StoreBroker/Pdp/en-us/PDP.xml
@@ -37,9 +37,10 @@
     <!-- _locComment_text="{MaxLength=255} App DevStudio" -->
   </DevStudio>
   <ReleaseNotes _locID="App_ReleaseNotes">
-    <!-- _locComment_text="{MaxLength=1500} App Release Note" -->1.5.0.0: Update to WinUI 3. Allow FTP access from localhost.
-    1.4.1.0: Fix the bug that non-ASCII characters show as garbage message on Windows.
-    1.4.0.0: Supports showing user connection logs.
+    <!-- _locComment_text="{MaxLength=1500} App Release Note" -->1.5.1.0: Fix the bug that logs and status updates are not shown.
+1.5.0.0: Update to WinUI 3. Allow FTP access from localhost.
+1.4.1.0: Fix the bug that non-ASCII characters show as garbage message on Windows.
+1.4.0.0: Supports showing user connection logs.
   </ReleaseNotes>
   <ScreenshotCaptions>
     <!-- Valid length: 200 character limit, up to 9 elements per platform -->

--- a/Publish/StoreBroker/Pdp/zh-cn/PDP.xml
+++ b/Publish/StoreBroker/Pdp/zh-cn/PDP.xml
@@ -37,9 +37,10 @@
     <!-- _locComment_text="{MaxLength=255} App DevStudio" -->
   </DevStudio>
   <ReleaseNotes _locID="App_ReleaseNotes">
-    <!-- _locComment_text="{MaxLength=1500} App Release Note" -->1.5.0.0：更新到WinUI 3。支持从本机访问FTP服务器。
-    1.4.1.0：修复非ASCII字符在Windows上显示为乱码的问题。
-    1.4.0.0：支持显示用户连接日志。
+    <!-- _locComment_text="{MaxLength=1500} App Release Note" -->1.5.1.0：修复日志和状态无法显示的问题。
+1.5.0.0：更新到WinUI 3。支持从本机访问FTP服务器。
+1.4.1.0：修复非ASCII字符在Windows上显示为乱码的问题。
+1.4.0.0：支持显示用户连接日志。
   </ReleaseNotes>
   <ScreenshotCaptions>
     <!-- Valid length: 200 character limit, up to 9 elements per platform -->

--- a/UniversalFtpServer.Package/Package.appxmanifest
+++ b/UniversalFtpServer.Package/Package.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" IgnorableNamespaces="uap rescap">
-  <Identity Name="8966ZhaobangChina.UniversalFTPServer" Publisher="CN=584E9342-CAA7-4820-8744-3B371B8C8C66" Version="1.5.0.0" />
+  <Identity Name="8966ZhaobangChina.UniversalFTPServer" Publisher="CN=584E9342-CAA7-4820-8744-3B371B8C8C66" Version="1.5.1.0" />
   <Properties>
     <DisplayName>Universal FTP Server</DisplayName>
     <PublisherDisplayName>兆邦中国(Zhaobang China)</PublisherDisplayName>

--- a/UniversalFtpServer/MainPage.xaml.cs
+++ b/UniversalFtpServer/MainPage.xaml.cs
@@ -22,7 +22,6 @@ using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Navigation;
 using Zhaobang.FtpServer;
-using System.Diagnostics;
 
 // https://go.microsoft.com/fwlink/?LinkId=402352&clcid=0x804 上介绍了“空白页”项模板
 
@@ -184,21 +183,21 @@ namespace UniversalFtpServer
             });
 
             server4Run = server4.RunAsync(cts.Token).ContinueWith(t =>
-                Debug.Assert(DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Normal, () =>
+                DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Normal, () =>
                 {
                     if (t.IsFaulted)
                         statusBlock4.Text = string.Format(loader.GetString(Ipv4Error), t.Exception);
                     else
                         statusBlock4.Text = loader.GetString(Ipv4Stopped);
-                })));
+                }));
             server6Run = server6.RunAsync(cts.Token).ContinueWith(t =>
-                Debug.Assert(DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Normal, () =>
+                DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Normal, () =>
                 {
                     if (t.IsFaulted)
                         statusBlock6.Text = string.Format(loader.GetString(Ipv6Error), t.Exception);
                     else
                         statusBlock6.Text = loader.GetString(Ipv6Stopped);
-                })));
+                }));
         }
 
         /// <summary>
@@ -209,11 +208,11 @@ namespace UniversalFtpServer
         /// <param name="remoteAddress">The remote address that invoked the command.</param>
         private void Tracer_CommandInvoked(string command, IPEndPoint remoteAddress)
         {
-            Debug.Assert(DispatcherQueue.TryEnqueue(() =>
+            DispatcherQueue.TryEnqueue(() =>
             {
                 var loader = new ResourceLoader();
                 PrintLog(string.Format(loader.GetString(CommandInvoked), command, remoteAddress));
-            }));
+            });
         }
 
         /// <summary>
@@ -222,20 +221,20 @@ namespace UniversalFtpServer
         /// <param name="remoteAddress">The remote address of the client.</param>
         private void Tracer_UserConnected(IPEndPoint remoteAddress)
         {
-            Debug.Assert(DispatcherQueue.TryEnqueue(() =>
+            DispatcherQueue.TryEnqueue(() =>
             {
                 var loader = new ResourceLoader();
                 PrintLog(string.Format(loader.GetString(UserConnected), remoteAddress));
-            }));
+            });
         }
 
         private void Tracer_ReplyInvoked(string replyCode, IPEndPoint remoteAddress)
         {
-            Debug.Assert(DispatcherQueue.TryEnqueue(() =>
+            DispatcherQueue.TryEnqueue(() =>
             {
                 var loader = new ResourceLoader();
                 PrintLog(string.Format(loader.GetString(ReplySent), replyCode, remoteAddress));
-            }));
+            });
         }
 
         /// <summary>
@@ -244,21 +243,21 @@ namespace UniversalFtpServer
         /// <param name="remoteAddress">The remote address of the client.</param>
         private void Tracer_UserDisconnected(IPEndPoint remoteAddress)
         {
-            Debug.Assert(DispatcherQueue.TryEnqueue(() =>
+            DispatcherQueue.TryEnqueue(() =>
             {
                 var loader = new ResourceLoader();
                 PrintLog(string.Format(loader.GetString(UserDisconnected), remoteAddress));
-            }));
+            });
         }
 
         private void NetworkInformation_NetworkStatusChanged(object sender)
         {
             var addresses = from host in NetworkInformation.GetHostNames()
                             select host.DisplayName;
-            Debug.Assert(DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Normal, () =>
+            DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Normal, () =>
             {
                 addressesBlock.Text = string.Join('\n', addresses);
-            }));
+            });
         }
 
         private void NotifyUser(string v)

--- a/UniversalFtpServer/UniversalFtpServer.csproj
+++ b/UniversalFtpServer/UniversalFtpServer.csproj
@@ -8,8 +8,8 @@
     <Platforms>x86;x64;arm64</Platforms>
     <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
     <UseWinUI>true</UseWinUI>
-    <AssemblyVersion>1.5.0.0</AssemblyVersion>
-    <FileVersion>1.5.0.0</FileVersion>
+    <AssemblyVersion>1.5.1.0</AssemblyVersion>
+    <FileVersion>1.5.1.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="MainPage.xaml" />


### PR DESCRIPTION
Remove the `Debug.Assert` call wrapping the `DispatcherQueue.TryEnqueue`, so that the `TryEnqueue` will not be optimized out in Release config.